### PR TITLE
update json to 1.8.6 due to not compiling in ruby 2.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     eventmachine (1.2.0.1)
     hashie (3.4.4)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     minitest (5.9.0)


### PR DESCRIPTION
ruby 2.4.0 is the default with chef > 13